### PR TITLE
Add an example spawn_cmd that dumps the syslog to onboard

### DIFF
--- a/res/doc
+++ b/res/doc
@@ -66,6 +66,7 @@
 #
 #   menu_item :main   :Show an Error  :dbg_error      :This is an error message!
 #   menu_item :main   :Do Nothing     :cmd_spawn      :sleep 60
+#   menu_item :main   :Dump Syslog    :cmd_spawn      :logread > /mnt/onboard/.adds/syslog.log
 #   menu_item :main   :Kernel Version :cmd_output     :500:uname -a
 #   menu_item :main   :Sketch Pad     :nickel_extras  :Sketch Pad
 #   menu_item :main   :Plato          :kfmon          :plato.png


### PR DESCRIPTION

Probably easier than to ask users to run it in a shell, or rely on
devmode's logging.