### PR TITLE
Allow whitespace in cmd_spawn/cmd_output args

### DIFF
--- a/src/action_cc.cc
+++ b/src/action_cc.cc
@@ -388,7 +388,12 @@ NM_ACTION_(cmd_spawn) {
     if (!cmd) {
         cmd = tmp;
     } else {
-        cmd = strtrim(cmd);
+        if (!quiet) {
+            // If there was an extra field, but with no recognizable option, assume it's a stray colon from the actual command
+            cmd = tmp;
+        } else {
+            cmd = strtrim(cmd);
+        }
     }
 
     QProcess proc;

--- a/src/action_cc.cc
+++ b/src/action_cc.cc
@@ -383,11 +383,12 @@ NM_ACTION_(cmd_spawn) {
     bool quiet = false;
     if (cmd && !strncmp(tmp1, "quiet", 5)) {
         quiet = true;
-        cmd = strtrim(cmd);
     }
     // Restore cmd if there was no option field
     if (!cmd) {
         cmd = tmp;
+    } else {
+        cmd = strtrim(cmd);
     }
 
     QProcess proc;

--- a/src/action_cc.cc
+++ b/src/action_cc.cc
@@ -345,7 +345,7 @@ NM_ACTION_(power) {
         N3PowerWorkflowManager *(*N3PowerWorkflowManager_sharedInstance)();
         reinterpret_cast<void*&>(N3PowerWorkflowManager_sharedInstance) = dlsym(RTLD_DEFAULT, "_ZN22N3PowerWorkflowManager14sharedInstanceEv");
         NM_ASSERT(N3PowerWorkflowManager_sharedInstance, "could not dlsym N3PowerWorkflowManager::sharedInstance, so cannot perform action cleanly (if you must, report a bug and use cmd_spawn instead)");
-        
+
         N3PowerWorkflowManager *pwm = N3PowerWorkflowManager_sharedInstance();
         NM_ASSERT(pwm, "could not get shared power manager pointer");
 
@@ -375,13 +375,21 @@ NM_ACTION_(power) {
 
 NM_ACTION_(cmd_spawn) {
     #define NM_ERR_RET nullptr
+
     char *tmp = strdup(arg);
+
     char *cmd = tmp;
+    char *tmp1 = strtrim(strsep(&cmd, ":"));
     bool quiet = false;
-    if (!strncmp(tmp, "quiet:", 6)) {
-        cmd += 6;
+    if (cmd && !strncmp(tmp1, "quiet", 5)) {
         quiet = true;
+        cmd = strtrim(cmd);
     }
+    // Restore cmd if there was no option field
+    if (!cmd) {
+        cmd = tmp;
+    }
+
     QProcess proc;
     uint64_t pid;
     bool ok = proc.startDetached(
@@ -396,6 +404,7 @@ NM_ACTION_(cmd_spawn) {
     free(tmp);
     NM_ASSERT(ok, "could not start process");
     NM_RETURN_OK(quiet ? nm_action_result_silent() : nm_action_result_toast("Successfully started process with PID %lu.", (unsigned long)(pid)));
+
     #undef NM_ERR_RET
 }
 
@@ -405,8 +414,9 @@ NM_ACTION_(cmd_output) {
     char *tmp = strdup(arg);
 
     char *cmd = tmp;
-    char *tmp1 = strsep(&cmd, ":"), *tmp2;
+    char *tmp1 = strtrim(strsep(&cmd, ":")), *tmp2;
     long timeout = strtol(tmp1, &tmp2, 10);
+    cmd = strtrim(cmd);
     NM_ASSERT(*tmp1 && !*tmp2 && timeout > 0 && timeout < 10000, "invalid timeout '%s'", tmp1);
 
     QProcess proc;

--- a/src/action_cc.cc
+++ b/src/action_cc.cc
@@ -377,12 +377,12 @@ NM_ACTION_(cmd_spawn) {
     #define NM_ERR_RET nullptr
     char *tmp = strdup(arg); // strsep and strtrim will modify it
     char *tmp1 = tmp; // so we can still free tmp later
-    char *tmp2 = strtrim(strsep(&tmp1, ":")); // get the part before the : into tmp1, if any
+    char *tmp2 = strtrim(strsep(&tmp1, ":")); // get the part before the : into tmp2, if any
 
     bool quiet = tmp1 && !strcmp(tmp2, "quiet");
     const char *cmd = (tmp1 && quiet)
         ? strtrim(tmp1) // trim the actual command
-        : arg; // restore the original arg if there was no option field or if it wasn't "quiet"
+        : arg; // restore the original arg if there wasn't any option field or if it wasn't "quiet"
 
     QProcess proc;
     uint64_t pid;

--- a/src/config.c
+++ b/src/config.c
@@ -1,5 +1,4 @@
 #define _GNU_SOURCE // asprintf
-#include <ctype.h>
 #include <dirent.h>
 #include <errno.h>
 #include <stdbool.h>
@@ -34,17 +33,6 @@ struct nm_config_t {
     } value;
     nm_config_t *next;
 };
-
-// strtrim trims ASCII whitespace in-place (i.e. don't give it a string literal)
-// from the left/right of the string.
-static char *strtrim(char *s){
-    if (!s) return NULL;
-    char *a = s, *b = s + strlen(s);
-    for (; a < b && isspace((unsigned char)(*a)); a++);
-    for (; b > a && isspace((unsigned char)(*(b-1))); b--);
-    *b = '\0';
-    return a;
-}
 
 static void nm_config_push_menu_item(nm_config_t **cfg, nm_menu_item_t *it) {
     nm_config_t *tmp = calloc(1, sizeof(nm_config_t));

--- a/src/util.h
+++ b/src/util.h
@@ -8,8 +8,21 @@ extern "C" {
 #define _GNU_SOURCE // asprintf
 #endif
 
+#include <ctype.h>
 #include <stdio.h>
+#include <string.h>
 #include <syslog.h>
+
+// strtrim trims ASCII whitespace in-place (i.e. don't give it a string literal)
+// from the left/right of the string.
+inline char *strtrim(char *s){
+    if (!s) return NULL;
+    char *a = s, *b = s + strlen(s);
+    for (; a < b && isspace((unsigned char)(*a)); a++);
+    for (; b > a && isspace((unsigned char)(*(b-1))); b--);
+    *b = '\0';
+    return a;
+}
 
 // A bunch of useful macros to simplify error handling and logging.
 


### PR DESCRIPTION
Fix #16

(Mildly tested, feel free to try to break it ;)).