### PR TITLE
Log the exact version at init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ override LDFLAGS  += -Wl,--no-undefined -Wl,-rpath,/usr/local/Kobo -Wl,-rpath,/u
 NM_VERSION:=$(shell git describe --tags)
 # Only use it if we got something useful out of git describe...
 ifdef NM_VERSION
-	override CPPFLAGS += -DNM_VERSION='"$(NM_VERSION)"'
+	CPPFLAGS += -DNM_VERSION='"$(NM_VERSION)"'
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,12 @@ LDFLAGS  ?= -Wl,--as-needed
 override CFLAGS   += -std=gnu11 -Wall -Wextra -Werror
 override CXXFLAGS += -std=gnu++11 -Wall -Wextra -Werror
 override LDFLAGS  += -Wl,--no-undefined -Wl,-rpath,/usr/local/Kobo -Wl,-rpath,/usr/local/Qt-5.2.1-arm/lib
+
+NM_VERSION:=$(shell git describe --tags)
+# Only use it if we got something useful out of git describe...
+ifdef NM_VERSION
+	override CPPFLAGS += -DNM_VERSION='"$(NM_VERSION)"'
+endif
 endif
 
 define GITIGNORE_HEAD

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ override LDFLAGS  += -Wl,--no-undefined -Wl,-rpath,/usr/local/Kobo -Wl,-rpath,/u
 NM_VERSION:=$(shell git describe --tags)
 # Only use it if we got something useful out of git describe...
 ifdef NM_VERSION
-	CPPFLAGS += -DNM_VERSION='"$(NM_VERSION)"'
+	override CPPFLAGS += -DNM_VERSION='"$(NM_VERSION)"'
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ override CFLAGS   += -std=gnu11 -Wall -Wextra -Werror
 override CXXFLAGS += -std=gnu++11 -Wall -Wextra -Werror
 override LDFLAGS  += -Wl,--no-undefined -Wl,-rpath,/usr/local/Kobo -Wl,-rpath,/usr/local/Qt-5.2.1-arm/lib
 
-NM_VERSION:=$(shell git describe --tags)
+NM_VERSION := $(shell git describe --tags --always --dirty)
 # Only use it if we got something useful out of git describe...
 ifdef NM_VERSION
 	override CPPFLAGS += -DNM_VERSION='"$(NM_VERSION)"'

--- a/src/init.c
+++ b/src/init.c
@@ -21,6 +21,7 @@ __attribute__((constructor)) void nm_init() {
 
     char *err;
 
+    NM_LOG("version: " NM_VERSION);
     NM_LOG("init: creating failsafe");
     nm_failsafe_t *fs;
     if (!(fs = nm_failsafe_create(&err)) && err) {

--- a/src/util.h
+++ b/src/util.h
@@ -13,6 +13,11 @@ extern "C" {
 #include <string.h>
 #include <syslog.h>
 
+// Fallback version tag
+#ifndef NM_VERSION
+#   define NM_VERSION "dev"
+#endif
+
 // strtrim trims ASCII whitespace in-place (i.e. don't give it a string literal)
 // from the left/right of the string.
 inline char *strtrim(char *s){

--- a/src/util.h
+++ b/src/util.h
@@ -15,7 +15,7 @@ extern "C" {
 
 // Fallback version tag
 #ifndef NM_VERSION
-#   define NM_VERSION "dev"
+#define NM_VERSION "dev"
 #endif
 
 // strtrim trims ASCII whitespace in-place (i.e. don't give it a string literal)


### PR DESCRIPTION
Might come in handy one day, because I know quite a few people extremely averse to updating stuff ^^.

e.g.,
```
May 13 17:57:13 nickel: (NickelMenu) version: v0.0.3-2-g043dfb3 (src/init.c:24)
May 13 17:57:13 nickel: (NickelMenu) init: creating failsafe (src/init.c:25)
```