### PR TITLE
Implement NM_UNINSTALL_CONFIGDIR build option

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,8 +11,18 @@ steps:
   when:
     event: [push, pull_request, tag]
   commands:
+  - make clean
   - make all koboroot
   - mkdir out && mv KoboRoot.tgz src/libnm.so out/
+- name: build-NM_UNINSTALL_CONFIGDIR
+  image: docker.io/geek1011/nickeltc:1.0
+  when:
+    event: [push, pull_request, tag]
+  commands:
+  - make clean
+  - make all koboroot NM_UNINSTALL_CONFIGDIR=1
+  - mkdir out/with-NM_UNINSTALL_CONFIGDIR && mv KoboRoot.tgz src/libnm.so out/with-NM_UNINSTALL_CONFIGDIR/
+  depends_on: [build]
 - name: test-syms
   image: golang:1.14
   when:
@@ -30,9 +40,9 @@ steps:
     access_key: nickelmenu
     secret_key: {from_secret: S3_SECRET_NICKELMENU}
     target: artifacts/build/${DRONE_BUILD_NUMBER}
-    source: out/*
+    source: out/**/*
     strip_prefix: out/
-  depends_on: [build]
+  depends_on: [build, build-NM_UNINSTALL_CONFIGDIR]
 - name: upload-tag
   image: plugins/s3
   when:
@@ -42,11 +52,9 @@ steps:
     access_key: nickelmenu
     secret_key: {from_secret: S3_SECRET_NICKELMENU}
     target: artifacts/tag/${DRONE_TAG}
-    source: out/*
+    source: out/**/*
     strip_prefix: out/
-    when:
-      event: [tag]
-  depends_on: [build]
+  depends_on: [build, build-NM_UNINSTALL_CONFIGDIR]
 - name: upload-commit
   image: plugins/s3
   when:
@@ -57,6 +65,6 @@ steps:
     access_key: nickelmenu
     secret_key: {from_secret: S3_SECRET_NICKELMENU}
     target: artifacts/commit/${DRONE_COMMIT}
-    source: out/*
+    source: out/**/*
     strip_prefix: out/
-  depends_on: [build]
+  depends_on: [build, build-NM_UNINSTALL_CONFIGDIR]

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,14 @@ override LDFLAGS  += -Wl,--no-undefined -Wl,-rpath,/usr/local/Kobo -Wl,-rpath,/u
 NM_VERSION := $(shell git describe --tags --always --dirty)
 # Only use it if we got something useful out of git describe...
 ifdef NM_VERSION
-	override CPPFLAGS += -DNM_VERSION='"$(NM_VERSION)"'
+ override CPPFLAGS += -DNM_VERSION='"$(NM_VERSION)"'
+endif
+
+ifeq ($(NM_UNINSTALL_CONFIGDIR),1)
+ $(info -- NM_UNINSTALL_CONFIGDIR... enabled)
+ override CPPFLAGS += -DNM_UNINSTALL_CONFIGDIR
+else
+ $(info -- NM_UNINSTALL_CONFIGDIR... disabled)
 endif
 endif
 

--- a/src/config.c
+++ b/src/config.c
@@ -15,14 +15,6 @@
 #include "menu.h"
 #include "util.h"
 
-#ifndef NM_CONFIG_DIR
-#define NM_CONFIG_DIR "/mnt/onboard/.adds/nm"
-#endif
-
-#ifndef NM_CONFIG_MAX_MENU_ITEMS_PER_MENU
-#define NM_CONFIG_MAX_MENU_ITEMS_PER_MENU 50
-#endif
-
 typedef enum {
     NM_CONFIG_TYPE_MENU_ITEM = 1,
     NM_CONFIG_TYPE_GENERATOR = 2,

--- a/src/config.h
+++ b/src/config.h
@@ -7,6 +7,14 @@ extern "C" {
 #include <stdbool.h>
 #include "menu.h"
 
+#ifndef NM_CONFIG_DIR
+#define NM_CONFIG_DIR "/mnt/onboard/.adds/nm"
+#endif
+
+#ifndef NM_CONFIG_MAX_MENU_ITEMS_PER_MENU
+#define NM_CONFIG_MAX_MENU_ITEMS_PER_MENU 50
+#endif
+
 typedef struct nm_config_t nm_config_t;
 
 // nm_config_parse parses the configuration files in /mnt/onboard/.adds/nm.


### PR DESCRIPTION
This option allows NickelMenu to be uninstalled by deleting the config dir.

Closes #34