### PR TITLE
Implement config file reloading and improve the config parser

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -33,7 +33,7 @@ nm_config_file_t *nm_config_files(char **err_out) {
 
     for (int i = 0; i < n; i++) {
         struct dirent *de = nl[i];
-        
+
         char *fn;
         if (asprintf(&fn, "%s/%s", NM_CONFIG_DIR, de->d_name) == -1)
             fn = NULL;
@@ -596,7 +596,7 @@ void nm_config_generate(nm_config_t *cfg) {
             }
 
             NM_LOG("config: ... %zu items generated", sz);
-            for (size_t i = 0; i < sz; i++) {
+            for (ssize_t i = sz-1; i >= 0; i--) {
                 nm_config_t *tmp = calloc(1, sizeof(nm_config_t));
                 tmp->type = NM_CONFIG_TYPE_MENU_ITEM;
                 tmp->value.menu_item = items[i];

--- a/src/config.c
+++ b/src/config.c
@@ -615,10 +615,10 @@ nm_menu_item_t **nm_config_get_menu(nm_config_t *cfg, size_t *n_out) {
     if (!it)
         return NULL;
 
-    nm_menu_item_t **tmp = &it[*n_out - 1];
+    nm_menu_item_t **tmp = it;
     for (nm_config_t *cur = cfg; cur; cur = cur->next)
         if (cur->type == NM_CONFIG_TYPE_MENU_ITEM)
-           *(tmp--) = cur->value.menu_item;
+           *(tmp++) = cur->value.menu_item;
 
     return it;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -454,8 +454,11 @@ static nm_config_parse__append__ret_t nm_config_parse__append_item(nm_config_par
         .action = NULL,
     };
 
-    if (!cfg_it_n->lbl)
+    if (!cfg_it_n->lbl) {
+        free(cfg_n);
+        free(cfg_it_n);
         return NM_CONFIG_PARSE__APPEND__RET_ALLOC_ERROR;
+    }
 
     if (state->cfg_c)
         state->cfg_c->next = cfg_n;
@@ -489,8 +492,10 @@ static nm_config_parse__append__ret_t nm_config_parse__append_action(nm_config_p
         .next       = NULL,
     };
 
-    if (!cfg_it_act_n->arg)
+    if (!cfg_it_act_n->arg) {
+        free(cfg_it_act_n);
         return NM_CONFIG_PARSE__APPEND__RET_ALLOC_ERROR;
+    }
 
     if (!state->cfg_it_c->action)
         state->cfg_it_c->action = cfg_it_act_n;
@@ -532,6 +537,8 @@ static nm_config_parse__append__ret_t nm_config_parse__append_generator(nm_confi
     if (!cfg_gn_n->desc || !cfg_gn_n->arg) {
         free(cfg_gn_n->desc);
         free(cfg_gn_n->arg);
+        free(cfg_n);
+        free(cfg_gn_n);
         return NM_CONFIG_PARSE__APPEND__RET_ALLOC_ERROR;
     }
 

--- a/src/config.c
+++ b/src/config.c
@@ -111,6 +111,8 @@ bool nm_config_files_update(nm_config_file_t **files, char **err_out) {
             ch = true;
             break;
         }
+        op = op->next;
+        np = np->next;
     }
 
     if (ch || op || np) {

--- a/src/config.c
+++ b/src/config.c
@@ -264,29 +264,29 @@ nm_config_t *nm_config_parse(nm_config_file_t *files, char **err_out) {
             char *s_typ = strtrim(strsep(&cur, ":"));
 
             if (nm_config_parse__line_item(s_typ, &cur, &tmp_it, &tmp_act, &err)) {
+                if (err)
+                    RETERR("file %s: line %d: parse menu_item: %s", cf->path, line_n, err);
                 if ((ret = nm_config_parse__append_item(&state, &tmp_it)))
                     RETERR("file %s: line %d: error appending item to config: %s", cf->path, line_n, nm_config_parse__strerror(ret));
                 if ((ret = nm_config_parse__append_action(&state, &tmp_act)))
                     RETERR("file %s: line %d: error appending action to config: %s", cf->path, line_n, nm_config_parse__strerror(ret));
                 continue;
-            } else if (err) {
-                RETERR("file %s: line %d: parse menu_item: %s", cf->path, line_n, err);
             }
 
             if (nm_config_parse__line_chain(s_typ, &cur, &tmp_act, &err)) {
+                if (err)
+                    RETERR("file %s: line %d: parse chain: %s", cf->path, line_n, err);
                 if ((ret = nm_config_parse__append_action(&state, &tmp_act)))
                     RETERR("file %s: line %d: error appending action to config: %s", cf->path, line_n, nm_config_parse__strerror(ret));
                 continue;
-            } else if (err) {
-                RETERR("file %s: line %d: parse chain: %s", cf->path, line_n, err);
             }
 
             if (nm_config_parse__line_generator(s_typ, &cur, &tmp_gn, &err)) {
+                if (err)
+                    RETERR("file %s: line %d: parse generator: %s", cf->path, line_n, err);
                 if ((ret = nm_config_parse__append_generator(&state, &tmp_gn)))
                     RETERR("file %s: line %d: error appending generator to config: %s", cf->path, line_n, nm_config_parse__strerror(ret));
                 continue;
-            } else if (err) {
-                RETERR("file %s: line %d: parse generator: %s", cf->path, line_n, err);
             }
 
             RETERR("file %s: line %d: field 1: unknown type '%s'", cf->path, line_n, s_typ);

--- a/src/config.c
+++ b/src/config.c
@@ -89,13 +89,18 @@ nm_config_file_t *nm_config_files(char **err_out) {
     #undef NM_ERR_RET
 }
 
-bool nm_config_files_current(nm_config_file_t **files, char **err_out) {
+bool nm_config_files_update(nm_config_file_t **files, char **err_out) {
     #define NM_ERR_RET false
     NM_ASSERT(files, "files pointer must not be null");
 
     nm_config_file_t *nfiles = nm_config_files(err_out);
     if (*err_out)
         return NM_ERR_RET;
+
+    if (!*files) {
+        *files = nfiles;
+        NM_RETURN_OK(true);
+    }
 
     bool ch = false;
     nm_config_file_t *op = *files;

--- a/src/config.c
+++ b/src/config.c
@@ -220,13 +220,15 @@ nm_config_t *nm_config_parse(nm_config_file_t *files, char **err_out) {
     nm_menu_action_t tmp_act;
     nm_generator_t   tmp_gn;
 
-    #define RETERR(fmt, ...) do {          \
-        if (cfgfile)                       \
-            fclose(cfgfile);               \
-        free(err);                         \
-        free(line);                        \
-        nm_config_free(state.cfg_c);       \
-        NM_RETURN_ERR(fmt, ##__VA_ARGS__); \
+    #define RETERR(fmt, ...) do {                  \
+        if (cfgfile)                               \
+            fclose(cfgfile);                       \
+        if (err_out)                               \
+            asprintf(err_out, fmt, ##__VA_ARGS__); \
+        free(err);                                 \
+        free(line);                                \
+        nm_config_free(state.cfg_c);               \
+        return NM_ERR_RET;                         \
     } while (0)
 
     for (nm_config_file_t *cf = files; cf; cf = cf->next) {

--- a/src/config.c
+++ b/src/config.c
@@ -120,7 +120,7 @@ bool nm_config_files_update(nm_config_file_t **files, char **err_out) {
     bool ch = false;
     nm_config_file_t *op = *files;
     nm_config_file_t *np = nfiles;
-    
+
     while (op && np) {
         if (strcmp(op->path, np->path) || op->mtime.tv_sec != np->mtime.tv_sec || op->mtime.tv_nsec != np->mtime.tv_nsec) {
             ch = true;

--- a/src/config.c
+++ b/src/config.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <time.h>
 
 #include "action.h"
 #include "config.h"

--- a/src/config.c
+++ b/src/config.c
@@ -292,6 +292,12 @@ nm_config_t *nm_config_parse(nm_config_file_t *files, char **err_out) {
             RETERR("file %s: line %d: field 1: unknown type '%s'", cf->path, line_n, s_typ);
         }
 
+        // reset the current per-file state
+        state.cfg_it_c     = NULL;
+        state.cfg_it_act_s = NULL;
+        state.cfg_it_act_c = NULL;
+        state.cfg_gn_c     = NULL;
+
         fclose(cfgfile);
         cfgfile = NULL;
     }

--- a/src/config.h
+++ b/src/config.h
@@ -5,6 +5,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <time.h>
 #include "menu.h"
 
 #ifndef NM_CONFIG_DIR
@@ -17,10 +18,23 @@ extern "C" {
 
 typedef struct nm_config_t nm_config_t;
 
-// nm_config_parse parses the configuration files in /mnt/onboard/.adds/nm.
-// An error is returned if there are syntax errors, file access errors, or
-// invalid action names for menu_item.
-nm_config_t *nm_config_parse(char **err_out);
+typedef struct nm_config_file_t nm_config_file_t;
+
+// nm_config_parse lists the configuration files in /mnt/onboard/.adds/nm. An
+// error is returned if there are errors reading the dir.
+nm_config_file_t *nm_config_files(char **err_out);
+
+// nm_config_files_update checks if the configuration files are up to date and
+// updates them, returning true, if not. Warning: if the files have changed,
+// the pointer passed to files will become invalid (it gets replaced).
+bool nm_config_files_update(nm_config_file_t **files, char **err_out);
+
+// nm_config_files_free frees the list of configuration files.
+void nm_config_files_free(nm_config_file_t *files);
+
+// nm_config_parse parses the configuration files. An error is returned if there
+// are syntax errors, file access errors, or invalid action names for menu_item.
+nm_config_t *nm_config_parse(nm_config_file_t *files, char **err_out);
 
 // nm_config_generate runs all generators synchronously and sequentially. Any
 // previously generated items are automatically removed.

--- a/src/config.h
+++ b/src/config.h
@@ -25,8 +25,11 @@ typedef struct nm_config_file_t nm_config_file_t;
 nm_config_file_t *nm_config_files(char **err_out);
 
 // nm_config_files_update checks if the configuration files are up to date and
-// updates them, returning true, if not. Warning: if the files have changed,
-// the pointer passed to files will become invalid (it gets replaced).
+// updates them, returning true, if not. If *files is NULL, it is equivalent to
+// doing `*files = nm_config_files(err_out)`. If an error occurs, the pointer is
+// left untouched and false is returned along with the error. Warning: if the
+// files have changed, the pointer passed to files will become invalid (it gets
+// replaced).
 bool nm_config_files_update(nm_config_file_t **files, char **err_out);
 
 // nm_config_files_free frees the list of configuration files.

--- a/src/config.h
+++ b/src/config.h
@@ -5,7 +5,6 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
-#include <time.h>
 #include "menu.h"
 
 #ifndef NM_CONFIG_DIR

--- a/src/failsafe.c
+++ b/src/failsafe.c
@@ -45,10 +45,8 @@ nm_failsafe_t *nm_failsafe_create(char **err_out) {
 static void *_nm_failsafe_destroy(void* _fs) {
     nm_failsafe_t *fs = (nm_failsafe_t*)(_fs);
 
-    if (fs->delay) {
-        NM_LOG("failsafe: restoring after %d seconds", fs->delay);
-        sleep(fs->delay);
-    }
+    NM_LOG("failsafe: restoring after %d seconds", fs->delay);
+    sleep(fs->delay);
 
     NM_LOG("failsafe: renaming %s to %s", fs->tmp, fs->orig);
     if (rename(fs->tmp, fs->orig))
@@ -64,11 +62,6 @@ static void *_nm_failsafe_destroy(void* _fs) {
 
 void nm_failsafe_destroy(nm_failsafe_t *fs, int delay) {
     fs->delay = delay;
-
-    if (!fs->delay) {
-        _nm_failsafe_destroy(fs);
-        return;
-    }
 
     NM_LOG("failsafe: scheduling restore");
 

--- a/src/failsafe.c
+++ b/src/failsafe.c
@@ -45,8 +45,10 @@ nm_failsafe_t *nm_failsafe_create(char **err_out) {
 static void *_nm_failsafe_destroy(void* _fs) {
     nm_failsafe_t *fs = (nm_failsafe_t*)(_fs);
 
-    NM_LOG("failsafe: restoring after %d seconds", fs->delay);
-    sleep(fs->delay);
+    if (fs->delay) {
+        NM_LOG("failsafe: restoring after %d seconds", fs->delay);
+        sleep(fs->delay);
+    }
 
     NM_LOG("failsafe: renaming %s to %s", fs->tmp, fs->orig);
     if (rename(fs->tmp, fs->orig))
@@ -62,6 +64,11 @@ static void *_nm_failsafe_destroy(void* _fs) {
 
 void nm_failsafe_destroy(nm_failsafe_t *fs, int delay) {
     fs->delay = delay;
+
+    if (!fs->delay) {
+        _nm_failsafe_destroy(fs);
+        return;
+    }
 
     NM_LOG("failsafe: scheduling restore");
 

--- a/src/init.c
+++ b/src/init.c
@@ -65,13 +65,15 @@ __attribute__((constructor)) void nm_init() {
         NM_LOG("init: error parsing config, will show a menu item with the error: %s", err);
     }
 
-    size_t ntmp;
+    size_t ntmp = -1;
     if (!upd) {
         NM_LOG("init: no config file changes detected for initial config update (it should always return an error or update), stopping (this is a bug; err should have been returned instead)");
         return;
-    } else if (nm_global_config_items(&ntmp)) {
+    } else if (!nm_global_config_items(&ntmp)) {
         NM_LOG("init: warning: no menu items returned by nm_global_config_items, ignoring for now (this is a bug; it should always have a menu item whether the default, an error, or the actual config)");
-    } else if (nm_global_config_items(&ntmp)) {
+    } else if (ntmp == -1) {
+        NM_LOG("init: warning: no size returned by nm_global_config_items, ignoring for now (this is a bug)");
+    } else if (!ntmp) {
         NM_LOG("init: warning: size returned by nm_global_config_items is 0, ignoring for now (this is a bug; it should always have a menu item whether the default, an error, or the actual config)");
     }
 

--- a/src/init.c
+++ b/src/init.c
@@ -65,13 +65,13 @@ __attribute__((constructor)) void nm_init() {
         NM_LOG("init: error parsing config, will show a menu item with the error: %s", err);
     }
 
-    size_t ntmp = -1;
+    size_t ntmp = SIZE_MAX;
     if (!upd) {
         NM_LOG("init: no config file changes detected for initial config update (it should always return an error or update), stopping (this is a bug; err should have been returned instead)");
         return;
     } else if (!nm_global_config_items(&ntmp)) {
         NM_LOG("init: warning: no menu items returned by nm_global_config_items, ignoring for now (this is a bug; it should always have a menu item whether the default, an error, or the actual config)");
-    } else if (ntmp == -1) {
+    } else if (ntmp == SIZE_MAX) {
         NM_LOG("init: warning: no size returned by nm_global_config_items, ignoring for now (this is a bug)");
     } else if (!ntmp) {
         NM_LOG("init: warning: size returned by nm_global_config_items is 0, ignoring for now (this is a bug; it should always have a menu item whether the default, an error, or the actual config)");

--- a/src/init.h
+++ b/src/init.h
@@ -1,0 +1,28 @@
+#ifndef NM_INIT_H
+#define NM_INIT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include "menu.h"
+
+// nm_global_config_update updates and regenerates the config if needed, and
+// returns true if it needed updating. If an error occurs, true is also returned
+// since the menu items will be updated to a single one showing the error (see
+// nm_global_config_items).
+bool nm_global_config_update(char **err_out);
+
+// nm_global_config_items returns an array of pointers with the current menu
+// items (the pointer and the items it points to will remain valid until the
+// next time nm_global_config_update is called). The number of items is stored
+// in the variable pointed to by n_out. If an error ocurred during the last time
+// nm_global_config_update was called, it is returned as a "Config Error" menu
+// item. If nm_global_config_update has never been called successfully before,
+// NULL is returned and n_out is set to 0.
+nm_menu_item_t **nm_global_config_items(size_t *n_out);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -7,8 +7,8 @@
 #include <cstdlib>
 #include <dlfcn.h>
 
-#include "action.h"
 #include "dlhook.h"
+#include "init.h"
 #include "menu.h"
 #include "util.h"
 
@@ -60,10 +60,7 @@ void (*MainWindowController_toast)(MainWindowController*, QString const&, QStrin
 static void (*LightMenuSeparator_LightMenuSeparator)(void*, QWidget*);
 static void (*BoldMenuSeparator_BoldMenuSeparator)(void*, QWidget*);
 
-static nm_menu_item_t **_items;
-static size_t _items_n;
-
-extern "C" int nm_menu_hook(void *libnickel, nm_menu_item_t **items, size_t items_n, char **err_out) {
+extern "C" int nm_menu_hook(void *libnickel, char **err_out) {
     #define NM_ERR_RET 1
     //libnickel 4.6 * _ZN28AbstractNickelMenuController18createMenuTextItemEP5QMenuRK7QStringbbS4_
     reinterpret_cast<void*&>(AbstractNickelMenuController_createMenuTextItem) = dlsym(libnickel, "_ZN28AbstractNickelMenuController18createMenuTextItemEP5QMenuRK7QStringbbS4_");
@@ -97,9 +94,6 @@ extern "C" int nm_menu_hook(void *libnickel, nm_menu_item_t **items, size_t item
     //libnickel 4.6 * _ZN28AbstractNickelMenuController18createMenuTextItemEP5QMenuRK7QStringbbS4_
     reinterpret_cast<void*&>(AbstractNickelMenuController_createMenuTextItem_orig) = nm_dlhook(libnickel, "_ZN28AbstractNickelMenuController18createMenuTextItemEP5QMenuRK7QStringbbS4_", nmh, &err);
     NM_ASSERT(AbstractNickelMenuController_createMenuTextItem_orig, "failed to hook _ZN28AbstractNickelMenuController18createMenuTextItemEP5QMenuRK7QStringbbS4_: %s", err);
-
-    _items = items;
-    _items_n = items_n;
 
     NM_RETURN_OK(0);
     #undef NM_ERR_RET
@@ -153,32 +147,45 @@ void _nm_menu_inject(void *nmc, QMenu *menu, nm_menu_location_t loc, int at) {
     if (before == nullptr)
         NM_LOG("it seems the original item to add new ones before was never actually added to the menu (number of items when the action was created is %d, current is %d), appending to end instead", at, actions.count());
 
+    NM_LOG("checking for config updates");
+    bool updated = nm_global_config_update(NULL); // if there was an error it will be returned as a menu item anyways (and updated will be true)
+    NM_LOG("updated = %d", updated);
+
     NM_LOG("checking for old items");
 
     for (auto action : actions) {
         if (action->property("nm_action") == true) {
-            return; // already added
-            /*menu->removeAction(action);
-            delete action;*/
+            if (!updated)
+                return; // already added items, up to date
+            menu->removeAction(action);
+            delete action;
         }
     }
 
     NM_LOG("injecting new items");
+
+    size_t items_n;
+    nm_menu_item_t **items = nm_global_config_items(&items_n);
+
+    if (!items) {
+        NM_LOG("items is NULL (either the config hasn't been parsed yet or there was a memory allocation error), not adding");
+        return;
+    }
 
     // if it segfaults in createMenuTextItem, it's likely because
     // AbstractNickelMenuController is invalid, which shouldn't happen while the
     // menu which we added the signal from still can be shown... (but
     // theoretically, it's possible)
 
-    for (size_t i = 0; i < _items_n; i++) {
-        nm_menu_item_t *it = _items[i];
+    for (size_t i = 0; i < items_n; i++) {
+        nm_menu_item_t *it = items[i];
         if (it->loc != loc)
             continue;
 
         NM_LOG("adding items '%s'...", it->lbl);
 
         MenuTextItem* item = AbstractNickelMenuController_createMenuTextItem_orig(nmc, menu, QString::fromUtf8(it->lbl), false, false, "");
-        QAction* action = AbstractNickelMenuController_createAction_before(before, loc, i == _items_n-1, nmc, menu, item, true, true, true);
+        QAction* action = AbstractNickelMenuController_createAction_before(before, loc, i == items_n-1, nmc, menu, item, true, true, true);
 
         action->setProperty("nm_action", true);
         QObject::connect(action, &QAction::triggered, [it](bool){

--- a/src/menu.cc
+++ b/src/menu.cc
@@ -295,12 +295,11 @@ QAction *AbstractNickelMenuController_createAction_before(QAction *before, nm_me
                 ? BoldMenuSeparator_BoldMenuSeparator
                 : LightMenuSeparator_LightMenuSeparator
             )(sep, reinterpret_cast<QWidget*>(_this));
-            sep->setProperty("nm_action", true);
             menu->insertAction(before, sep);
         } else {
             sep = menu->insertSeparator(before);
-            sep->setProperty("nm_action", true);
         }
+        sep->setProperty("nm_action", true);
     }
 
     return action;

--- a/src/menu.h
+++ b/src/menu.h
@@ -28,12 +28,9 @@ typedef struct {
     nm_menu_action_t *action;
 } nm_menu_item_t;
 
-// nm_menu_hook hooks a dlopen'd libnickel handle to add the specified menus,
-// and returns 0 on success, or 1 with err_out (if provided) set to the malloc'd
-// error message on error. The provided configuration and all pointers it
-// references must remain valid for the lifetime of the program (i.e. not stack
-// allocated). It MUST NOT be called more than once.
-int nm_menu_hook(void *libnickel, nm_menu_item_t **items, size_t items_n, char **err_out);
+// nm_menu_hook hooks a dlopen'd libnickel handle. It MUST NOT be called more
+// than once.
+int nm_menu_hook(void *libnickel, char **err_out);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR implements config file reloading.

Every time the menu is opened, the config files are scanned. If the number of files or the modification time of one changes, they are re-parsed and re-generated. If there is a config error or I/O error while parsing or scanning the files, an item is added showing it like usual. If there aren't any config entries, the usual one referring to the documentation is shown.

There should not be any noticeable delay in opening the menu, except around another 200ms (up to 500ms) when opening it after a config change.

closes #42

---

For the config parser improvements, see https://github.com/geek1011/NickelMenu/pull/47#issuecomment-646444323.

closes #48