### PR TITLE
Add Instapaper support for latest Kobo firmware v4.43.23418

### DIFF
--- a/res/doc
+++ b/res/doc
@@ -122,6 +122,7 @@
 #                                          library:authors           - Authors
 #                                          library:series            - Series (4.20.14601+)
 #                                          library:shelves           - Collections
+#                                          library:pocket            - Articles
 #                                          library:instapaper        - Instapaper
 #                                          library:dropbox           - Dropbox (4.18.13737+)
 #                                          reading_life:reading_life - Activity (with last tab)

--- a/src/action_cc.cc
+++ b/src/action_cc.cc
@@ -125,7 +125,8 @@ NM_ACTION_(nickel_open) {
         else if (!strcmp(arg2, "authors"))  sym_f = "_ZN15LibraryNavMixin11showAuthorsEv";             //libnickel 4.6 * _ZN15LibraryNavMixin11showAuthorsEv
         else if (!strcmp(arg2, "series"))   sym_f = "_ZN15LibraryNavMixin10showSeriesEv";              //libnickel 4.20.14601 * _ZN15LibraryNavMixin10showSeriesEv
         else if (!strcmp(arg2, "shelves"))  sym_f = "_ZN15LibraryNavMixin11showShelvesEv";             //libnickel 4.6 * _ZN15LibraryNavMixin11showShelvesEv
-        else if (!strcmp(arg2, "instapaper")) sym_f = "_ZN15LibraryNavMixin21showInstapaperLibraryEv"; //libnickel latest * _ZN15LibraryNavMixin21showInstapaperLibraryEv
+        else if (!strcmp(arg2, "pocket"))   sym_f = "_ZN15LibraryNavMixin17showPocketLibraryEv";       //libnickel 4.6 * _ZN15LibraryNavMixin17showPocketLibraryEv
+        else if (!strcmp(arg2, "instapaper")) sym_f = "_ZN15LibraryNavMixin21showInstapaperLibraryEv"; //libnickel 4.43.23418 * _ZN15LibraryNavMixin21showInstapaperLibraryEv
         else if (!strcmp(arg2, "dropbox"))  sym_f = "_ZN15LibraryNavMixin11showDropboxEv";             //libnickel 4.18.13737 4.22.15268 _ZN15LibraryNavMixin11showDropboxEv
     } else if (!strcmp(arg1, "reading_life")) {
         sym_c = "_ZN19ReadingLifeNavMixinC1Ev"; //libnickel 4.6 * _ZN19ReadingLifeNavMixinC1Ev


### PR DESCRIPTION
## Summary
Recent Kobo firmware versions have replaced Pocket with Instapaper. This PR updates NickelMenu to support the new Instapaper functionality.

## Changes
- **src/action_cc.cc**: Replace `library:pocket` with `library:instapaper` and update symbol to `_ZN15LibraryNavMixin21showInstapaperLibraryEv`
- **res/doc**: Update documentation to reflect Instapaper instead of Articles/Pocket

## Testing
- Tested on Kobo Libra Colour kobo13 v4.43.23418 firmware
- Symbol verified using `strings` command on `libnickel.so.1.0.0`
- Menu item successfully opens Instapaper library view

## Usage
```
menu_item:main:Instapaper:nickel_open:library:instapaper
```