### PR TITLE
Add experimental options to style the 15505+ main menu popover to match stock Nickel (caret, separators, position, width)

### DIFF
--- a/res/doc
+++ b/res/doc
@@ -212,12 +212,32 @@
 #                  label            - sets the label used for the NickelMenu button on 4.23.15505+
 #                  icon             - sets the icon used for the NickelMenu button on 4.23.15505+
 #                  icon_active      - sets the active icon used for the NickelMenu button on 4.23.15505+
+#                  caret            - set to 1 to draw the native popover caret/pointer on the from-scratch
+#                                     main menu popover on 4.23.15505+ (menu-level, NOT per-button or indexed;
+#                                     default off). The caret is aimed at the NickelMenu tab button.
+#                  decoration       - the DecorationPosition (integer) edge the caret is drawn on, used with
+#                                     caret=1 on 4.23.15505+ (menu-level; default 3). Values: 0=top, 1=right,
+#                                     2=left, 3=bottom, 5=none.
+#                  caret_dx         - signed horizontal nudge (pixels) of the caret anchor point (menu-level;
+#                                     default 0; used with caret=1)
+#                  caret_dy         - signed vertical nudge (pixels) of the caret anchor point (menu-level;
+#                                     default 0; used with caret=1)
+#                  offset_x         - signed horizontal nudge (pixels) of the main menu popover on 4.23.15505+
+#                                     (menu-level; default 0; negative moves it left, away from the screen edge)
+#                  offset_y         - signed vertical nudge (pixels) of the main menu popover on 4.23.15505+
+#                                     (menu-level; default 0)
 #
 #     <val>  the option value:
 #              (..)_enabled     -> 0 or 1
 #              (..)_label       -> the label to use instead of the default value
 #              (..)_icon        -> the path passed to QPixmap
 #              (..)_icon_active -> the path passed to QPixmap
+#              (..)_caret       -> 0 or 1 (default 0)
+#              (..)_decoration  -> a DecorationPosition integer (default 3; 0=top 1=right 2=left 3=bottom 5=none)
+#              (..)_caret_dx    -> a signed integer number of pixels (default 0)
+#              (..)_caret_dy    -> a signed integer number of pixels (default 0)
+#              (..)_offset_x    -> a signed integer number of pixels (default 0)
+#              (..)_offset_y    -> a signed integer number of pixels (default 0)
 #
 # For example, you might have a configuration file named "mystuff" like:
 #

--- a/res/doc
+++ b/res/doc
@@ -231,6 +231,16 @@
 #                                     default 0; negative moves it up)
 #                  width            - fixed width (pixels) of the main menu popover on 4.23.15505+
 #                                     (menu-level; default 0 = auto-size to the widest menu item)
+#                  flush_separators - set to 1 to draw the main menu popover's row dividers with Nickel's
+#                                     native separator stretched to the popover edges (like the stock
+#                                     popovers) instead of QMenu's inset separator on 4.23.15505+
+#                                     (menu-level; default off)
+#                  separator_inset  - pixels each divider is inset from the popover edges when
+#                                     flush_separators is 1; use to line the dividers up with the painted
+#                                     border (menu-level; default 0)
+#                  italic           - set to 0 to render the main menu popover's items with the normal
+#                                     (non-italic) menu font on 4.23.15505+ (menu-level; default 1, the
+#                                     stock italic look)
 #
 #     <val>  the option value:
 #              (..)_enabled     -> 0 or 1

--- a/res/doc
+++ b/res/doc
@@ -229,6 +229,8 @@
 #                  offset_y         - signed vertical nudge (pixels) of the main menu popover on 4.23.15505+,
 #                                     applied AFTER the popup is positioned and screen-fitted (menu-level;
 #                                     default 0; negative moves it up)
+#                  width            - fixed width (pixels) of the main menu popover on 4.23.15505+
+#                                     (menu-level; default 0 = auto-size to the widest menu item)
 #
 #     <val>  the option value:
 #              (..)_enabled     -> 0 or 1

--- a/res/doc
+++ b/res/doc
@@ -222,10 +222,13 @@
 #                                     default 0; used with caret=1)
 #                  caret_dy         - signed vertical nudge (pixels) of the caret anchor point (menu-level;
 #                                     default 0; used with caret=1)
-#                  offset_x         - signed horizontal nudge (pixels) of the main menu popover on 4.23.15505+
-#                                     (menu-level; default 0; negative moves it left, away from the screen edge)
-#                  offset_y         - signed vertical nudge (pixels) of the main menu popover on 4.23.15505+
-#                                     (menu-level; default 0)
+#                  offset_x         - signed horizontal nudge (pixels) of the main menu popover on 4.23.15505+,
+#                                     applied AFTER the popup is positioned and screen-fitted, i.e. relative to
+#                                     where the menu visually lands (menu-level; default 0; negative moves it
+#                                     left, away from the screen edge)
+#                  offset_y         - signed vertical nudge (pixels) of the main menu popover on 4.23.15505+,
+#                                     applied AFTER the popup is positioned and screen-fitted (menu-level;
+#                                     default 0; negative moves it up)
 #
 #     <val>  the option value:
 #              (..)_enabled     -> 0 or 1

--- a/src/nickelmenu.cc
+++ b/src/nickelmenu.cc
@@ -541,7 +541,17 @@ extern "C" __attribute__((visibility("default"))) void _nm_menu_hook2(MainNavVie
         }
 
         menu->ensurePolished();
-        menu->popup(btn->mapToGlobal(btn->geometry().topRight() - QPoint(0, menu->sizeHint().height()) + QPoint(nm_offx, nm_offy)));
+        menu->popup(btn->mapToGlobal(btn->geometry().topRight() - QPoint(0, menu->sizeHint().height())));
+        // Apply the configured nudge AFTER popup(): popup()'s screen-fit
+        // clamping repositions the menu (the stock popup point is far
+        // off-screen right, so the clamp engages every time), which would
+        // swallow any pre-popup offset. Post-popup move() makes the offsets
+        // relative to the on-screen position the menu actually landed at.
+        if (nm_offx || nm_offy) {
+            menu->move(menu->pos() + QPoint(nm_offx, nm_offy));
+            NM_LOG("librito popup: nudged by (%d,%d) to (%d,%d), size=%dx%d",
+                nm_offx, nm_offy, menu->pos().x(), menu->pos().y(), menu->width(), menu->height());
+        }
     });
 
     bl->addWidget(btn, 1);

--- a/src/nickelmenu.cc
+++ b/src/nickelmenu.cc
@@ -13,6 +13,7 @@
 #include <QWidgetAction>
 
 #include <cstdlib>
+#include <cstring>
 
 #include <NickelHook.h>
 
@@ -81,13 +82,13 @@ typedef int DecorationPosition;
 void (*NickelTouchMenu_NickelTouchMenu)(NickelTouchMenu*, QWidget* parent, DecorationPosition position);
 void (*MenuTextItem_MenuTextItem)(MenuTextItem*, QWidget* parent, bool checkable, bool italic);
 void (*MenuTextItem_setText)(MenuTextItem*, QString const& text);
+void (*MenuTextItem_setTextItalics)(MenuTextItem*, bool italic);
 void (*MenuTextItem_registerForTapGestures)(MenuTextItem*);
 
-// NickelMenu+Librito: NickelTouchMenu decoration (caret/pointer) API. Resolved
-// optionally (15505+); used only when the menu_main_15505_caret option is set.
-// The caret paints only when showDecoration(true) is set AND a target rect is
-// given (paintEvent gates drawDecoration on the flag; drawDecoration aims the
-// caret at the target rect's centre).
+// NickelTouchMenu decoration (caret/pointer) API. Resolved optionally
+// (15505+); used only when the menu_main_15505_caret option is set. The caret
+// paints only when showDecoration(true) is set AND a target rect is given
+// (paintEvent gates drawDecoration on the flag).
 void (*NickelTouchMenu_showDecoration)(NickelTouchMenu*, bool);
 void (*NickelTouchMenu_setTargetRect)(NickelTouchMenu*, QRect const&);
 void (*NickelTouchMenu_setDecorationPosition)(NickelTouchMenu*, DecorationPosition);
@@ -152,6 +153,7 @@ static struct nh_dlsym NickelMenuDlsym[] = {
     {.name = "_ZN15NickelTouchMenuC2EP7QWidget18DecorationPosition", .out = nh_symoutptr(NickelTouchMenu_NickelTouchMenu),     .desc = "bottom nav main menu button injection (15505+)", .optional = true}, //libnickel 4.23.15505 * _ZN15NickelTouchMenuC2EP7QWidget18DecorationPosition
     {.name = "_ZN12MenuTextItemC1EP7QWidgetbb",                      .out = nh_symoutptr(MenuTextItem_MenuTextItem),           .desc = "bottom nav main menu button injection (15505+)", .optional = true}, //libnickel 4.23.15505 * _ZN12MenuTextItemC1EP7QWidgetbb
     {.name = "_ZN12MenuTextItem7setTextERK7QString",                 .out = nh_symoutptr(MenuTextItem_setText),                .desc = "bottom nav main menu button injection (15505+)", .optional = true}, //libnickel 4.23.15505 * _ZN12MenuTextItem7setTextERK7QString
+    {.name = "_ZN12MenuTextItem14setTextItalicsEb",                  .out = nh_symoutptr(MenuTextItem_setTextItalics),         .desc = "main menu popover italics (15505+)",             .optional = true}, //libnickel 4.23.15505 * _ZN12MenuTextItem14setTextItalicsEb
     {.name = "_ZN12MenuTextItem22registerForTapGesturesEv",          .out = nh_symoutptr(MenuTextItem_registerForTapGestures), .desc = "bottom nav main menu button injection (15505+)", .optional = true}, //libnickel 4.23.15505 * _ZN12MenuTextItem22registerForTapGesturesEv
 
     // main menu popover caret/decoration (15505+) — optional; used by menu_main_15505_caret
@@ -428,12 +430,12 @@ extern "C" __attribute__((visibility("default"))) void _nm_menu_hook2(MainNavVie
             return;
         }
 
-        // NickelMenu+Librito: make the from-scratch main-menu popover's pointer
-        // decoration and position configurable. Defaults preserve stock behaviour
-        // (decoration 3 = no caret, zero offset), so this is a no-op unless set.
+        // Appearance options for the from-scratch main-menu popover. Defaults
+        // preserve the stock appearance, so all of these are no-ops unless set.
         // `decoration` is the DecorationPosition enum Nickel draws its native
-        // popover caret with; offset_x/_y nudge the popup so the caret lands on
-        // the tab button and add a screen-edge margin.
+        // popover caret with (the caret itself is gated on `caret`, since it
+        // also needs a parent and a target rect — see below); offset_x/_y nudge
+        // the popup, e.g. to add a screen-edge margin.
         const char *nm_deco_s  = nm_global_config_experimental("menu_main_15505_decoration");
         const char *nm_offx_s  = nm_global_config_experimental("menu_main_15505_offset_x");
         const char *nm_offy_s  = nm_global_config_experimental("menu_main_15505_offset_y");
@@ -442,6 +444,10 @@ extern "C" __attribute__((visibility("default"))) void _nm_menu_hook2(MainNavVie
         int  nm_offx  = nm_offx_s ? (int) strtol(nm_offx_s, nullptr, 10) : 0;
         int  nm_offy  = nm_offy_s ? (int) strtol(nm_offy_s, nullptr, 10) : 0;
         bool nm_caret = nm_caret_s && nm_caret_s[0] == '1';
+        const char *nm_fsep_s = nm_global_config_experimental("menu_main_15505_flush_separators");
+        bool nm_fsep = nm_fsep_s && nm_fsep_s[0] == '1';
+        const char *nm_ital_s = nm_global_config_experimental("menu_main_15505_italic");
+        bool nm_ital = nm_ital_s ? nm_ital_s[0] == '1' : true; // stock items are italic
 
         // The caret (drawDecoration) hard-requires a parent widget: its first
         // check is `if (!d->parent) return`, and it maps the caret anchor point
@@ -468,8 +474,12 @@ extern "C" __attribute__((visibility("default"))) void _nm_menu_hook2(MainNavVie
                 return;
             }
 
-            MenuTextItem_MenuTextItem(mti, menu, false, true);
+            MenuTextItem_MenuTextItem(mti, menu, false, nm_ital);
             MenuTextItem_setText(mti, QString::fromUtf8(it->lbl));
+            // setText re-applies the item's italics, so the explicit setter is
+            // needed in addition to the constructor flag.
+            if (!nm_ital && MenuTextItem_setTextItalics)
+                MenuTextItem_setTextItalics(mti, false);
             MenuTextItem_registerForTapGestures(mti); // this only makes the MenuTextItem::tapped signal connect so it highlights on tap, doesn't apply to the QAction::triggered below (which needs another GestureReceiver somewhere)
 
             // based on _ZN22AbstractMenuController12createActionEP5QMenuP7QWidgetbbb
@@ -482,8 +492,22 @@ extern "C" __attribute__((visibility("default"))) void _nm_menu_hook2(MainNavVie
 
             QWidget::connect(ac, &QAction::triggered, menu, &QMenu::hide);
 
-            if (i != items_n-1)
-                menu->addSeparator();
+            if (i != items_n-1) {
+                // Stock popovers draw full-width dividers with Nickel's own
+                // separator action (an 8-byte QAction subclass, same pattern as
+                // the pre-15505 main menu above); QMenu::addSeparator() insets
+                // the line from the popover edges.
+                QAction *nm_sep = nullptr;
+                if (nm_fsep && LightMenuSeparator_LightMenuSeparator) {
+                    nm_sep = reinterpret_cast<QAction*>(calloc(1, 32)); // it's actually 8 as of 14622, but better to be safe
+                    if (nm_sep) {
+                        LightMenuSeparator_LightMenuSeparator(nm_sep, menu);
+                        menu->addAction(nm_sep);
+                    }
+                }
+                if (!nm_sep)
+                    menu->addSeparator();
+            }
 
             // shim so we don't need to deal with GestureReceiver directly like _ZN28AbstractNickelMenuController18createMenuTextItemEP5QMenuRK7QStringbbS4_ does
             // (similar to _ZN23SelectionMenuController11addMenuItemEP17SelectionMenuViewP12MenuTextItemPKc)
@@ -508,15 +532,10 @@ extern "C" __attribute__((visibility("default"))) void _nm_menu_hook2(MainNavVie
 
         QWidget::connect(menu, &QMenu::aboutToHide, menu, &QWidget::deleteLater);
 
-        // NickelMenu+Librito: enable the native popover caret when requested.
-        // paintEvent only calls drawDecoration if showDecoration(true) was set,
-        // and drawDecoration aims the caret at setTargetRect()'s centre — so both
-        // are required. setDecorationPosition picks the edge (0..4; 5 = none).
-        NM_LOG("librito caret: nm_caret=%d deco=%d haveShowDeco=%d haveSetTgt=%d haveSetPos=%d",
-            (int) nm_caret, nm_deco,
-            NickelTouchMenu_showDecoration != nullptr,
-            NickelTouchMenu_setTargetRect != nullptr,
-            NickelTouchMenu_setDecorationPosition != nullptr);
+        // Enable the native popover caret when requested. paintEvent only calls
+        // drawDecoration if showDecoration(true) was set, and the caret needs a
+        // target to aim at — so both are required. setDecorationPosition picks
+        // the edge (0=top, 1=right, 2=left, 3=bottom, 5=none).
         if (nm_caret && NickelTouchMenu_showDecoration && NickelTouchMenu_setTargetRect) {
             NickelTouchMenu_showDecoration(menu, true);
             if (NickelTouchMenu_setDecorationPosition)
@@ -534,10 +553,8 @@ extern "C" __attribute__((visibility("default"))) void _nm_menu_hook2(MainNavVie
                 int nm_cdy = nm_cdy_s ? (int) strtol(nm_cdy_s, nullptr, 10) : 0;
                 QPoint nm_anchor = nm_tgt.topLeft() + QPoint(nm_cdx, nm_cdy);
                 NickelTouchMenu_setDecorationPositionOffset(menu, nm_anchor);
-                NM_LOG("librito caret: anchor=(%d,%d)", nm_anchor.x(), nm_anchor.y());
             }
-            NM_LOG("librito caret: ENABLED deco=%d parent=%p target=(%d,%d %dx%d)",
-                nm_deco, (void*) nm_parent, nm_tgt.x(), nm_tgt.y(), nm_tgt.width(), nm_tgt.height());
+            NM_LOG("enabled menu caret (edge=%d)", nm_deco);
         }
 
         // Optional fixed popover width (pixels). Default (unset/0) keeps the
@@ -556,8 +573,45 @@ extern "C" __attribute__((visibility("default"))) void _nm_menu_hook2(MainNavVie
         // relative to the on-screen position the menu actually landed at.
         if (nm_offx || nm_offy) {
             menu->move(menu->pos() + QPoint(nm_offx, nm_offy));
-            NM_LOG("librito popup: nudged by (%d,%d) to (%d,%d), size=%dx%d",
-                nm_offx, nm_offy, menu->pos().x(), menu->pos().y(), menu->width(), menu->height());
+            NM_LOG("nudged menu by (%d,%d)", nm_offx, nm_offy);
+        }
+        // Stretch the separator widgets to the popover's full width. The menu
+        // lays out every action (items and separators alike) inset from the
+        // edges, so even Nickel's native separator renders with side gaps; the
+        // stock popovers draw their dividers edge-to-edge. Done after popup()
+        // so the layout has already assigned geometry (the menu is rebuilt on
+        // every open, so this re-applies each time).
+        if (nm_fsep) {
+            // The widget's true edge sits outside the painted frame, so a
+            // separate inset (pixels from each edge) lines the dividers up
+            // with the visible border. Default 0 = the widget's full width.
+            const char *nm_si_s = nm_global_config_experimental("menu_main_15505_separator_inset");
+            int nm_si = nm_si_s ? (int) strtol(nm_si_s, nullptr, 10) : 0;
+            int nm_fixed = 0;
+            for (QAction *nm_a : menu->actions()) {
+                if (!nm_a->isSeparator())
+                    continue;
+                QWidgetAction *nm_wa = qobject_cast<QWidgetAction*>(nm_a);
+                QWidget *nm_w = nm_wa ? nm_wa->defaultWidget() : nullptr;
+                if (nm_w) {
+                    QRect nm_g = nm_w->geometry();
+                    nm_w->setGeometry(nm_si, nm_g.y(), menu->width() - 2*nm_si, nm_g.height());
+                    nm_fixed++;
+                }
+            }
+            if (!nm_fixed) {
+                // The separator action may create its widget via
+                // QWidgetAction::createWidget() rather than setDefaultWidget();
+                // catch those as direct children by class name.
+                for (QWidget *nm_w : menu->findChildren<QWidget*>()) {
+                    if (strcmp(nm_w->metaObject()->className(), "LightMenuSeparator") != 0)
+                        continue;
+                    QRect nm_g = nm_w->geometry();
+                    nm_w->setGeometry(nm_si, nm_g.y(), menu->width() - 2*nm_si, nm_g.height());
+                    nm_fixed++;
+                }
+            }
+            NM_LOG("stretched %d separators (inset=%d)", nm_fixed, nm_si);
         }
     });
 

--- a/src/nickelmenu.cc
+++ b/src/nickelmenu.cc
@@ -540,6 +540,13 @@ extern "C" __attribute__((visibility("default"))) void _nm_menu_hook2(MainNavVie
                 nm_deco, (void*) nm_parent, nm_tgt.x(), nm_tgt.y(), nm_tgt.width(), nm_tgt.height());
         }
 
+        // Optional fixed popover width (pixels). Default (unset/0) keeps the
+        // stock behaviour: auto-sized to the widest menu item.
+        const char *nm_w_s = nm_global_config_experimental("menu_main_15505_width");
+        int nm_w = nm_w_s ? (int) strtol(nm_w_s, nullptr, 10) : 0;
+        if (nm_w > 0)
+            menu->setFixedWidth(nm_w);
+
         menu->ensurePolished();
         menu->popup(btn->mapToGlobal(btn->geometry().topRight() - QPoint(0, menu->sizeHint().height())));
         // Apply the configured nudge AFTER popup(): popup()'s screen-fit

--- a/src/nickelmenu.cc
+++ b/src/nickelmenu.cc
@@ -5,6 +5,7 @@
 #include <QMenu>
 #include <QMetaProperty>
 #include <QPushButton>
+#include <QRect>
 #include <QRegularExpression>
 #include <QString>
 #include <QUrl>
@@ -82,6 +83,16 @@ void (*MenuTextItem_MenuTextItem)(MenuTextItem*, QWidget* parent, bool checkable
 void (*MenuTextItem_setText)(MenuTextItem*, QString const& text);
 void (*MenuTextItem_registerForTapGestures)(MenuTextItem*);
 
+// NickelMenu+Librito: NickelTouchMenu decoration (caret/pointer) API. Resolved
+// optionally (15505+); used only when the menu_main_15505_caret option is set.
+// The caret paints only when showDecoration(true) is set AND a target rect is
+// given (paintEvent gates drawDecoration on the flag; drawDecoration aims the
+// caret at the target rect's centre).
+void (*NickelTouchMenu_showDecoration)(NickelTouchMenu*, bool);
+void (*NickelTouchMenu_setTargetRect)(NickelTouchMenu*, QRect const&);
+void (*NickelTouchMenu_setDecorationPosition)(NickelTouchMenu*, DecorationPosition);
+void (*NickelTouchMenu_setDecorationPositionOffset)(NickelTouchMenu*, QPoint const&);
+
 // Selection menu stuff (14622+).
 typedef void SelectionMenuController; // note: items are re-initialized every time the menu is opened
 typedef QWidget SelectionMenuView;
@@ -142,6 +153,12 @@ static struct nh_dlsym NickelMenuDlsym[] = {
     {.name = "_ZN12MenuTextItemC1EP7QWidgetbb",                      .out = nh_symoutptr(MenuTextItem_MenuTextItem),           .desc = "bottom nav main menu button injection (15505+)", .optional = true}, //libnickel 4.23.15505 * _ZN12MenuTextItemC1EP7QWidgetbb
     {.name = "_ZN12MenuTextItem7setTextERK7QString",                 .out = nh_symoutptr(MenuTextItem_setText),                .desc = "bottom nav main menu button injection (15505+)", .optional = true}, //libnickel 4.23.15505 * _ZN12MenuTextItem7setTextERK7QString
     {.name = "_ZN12MenuTextItem22registerForTapGesturesEv",          .out = nh_symoutptr(MenuTextItem_registerForTapGestures), .desc = "bottom nav main menu button injection (15505+)", .optional = true}, //libnickel 4.23.15505 * _ZN12MenuTextItem22registerForTapGesturesEv
+
+    // main menu popover caret/decoration (15505+) — optional; used by menu_main_15505_caret
+    {.name = "_ZN15NickelTouchMenu14showDecorationEb",                           .out = nh_symoutptr(NickelTouchMenu_showDecoration),             .desc = "main menu popover caret (15505+)", .optional = true}, //libnickel 4.23.15505 * _ZN15NickelTouchMenu14showDecorationEb
+    {.name = "_ZN15NickelTouchMenu13setTargetRectERK5QRect",                     .out = nh_symoutptr(NickelTouchMenu_setTargetRect),              .desc = "main menu popover caret (15505+)", .optional = true}, //libnickel 4.23.15505 * _ZN15NickelTouchMenu13setTargetRectERK5QRect
+    {.name = "_ZN15NickelTouchMenu21setDecorationPositionE18DecorationPosition", .out = nh_symoutptr(NickelTouchMenu_setDecorationPosition),       .desc = "main menu popover caret (15505+)", .optional = true}, //libnickel 4.23.15505 * _ZN15NickelTouchMenu21setDecorationPositionE18DecorationPosition
+    {.name = "_ZN15NickelTouchMenu27setDecorationPositionOffsetERK6QPoint",      .out = nh_symoutptr(NickelTouchMenu_setDecorationPositionOffset), .desc = "main menu popover caret (15505+)", .optional = true}, //libnickel 4.23.15505 * _ZN15NickelTouchMenu27setDecorationPositionOffsetERK6QPoint
 
     // selection menu injection (14622+)
     {.name = "_ZN17SelectionMenuView11addMenuItemEP12MenuTextItem", .out = nh_symoutptr(SelectionMenuView_addMenuItem),           .desc = "selection menu injection (14622+)",        .optional = true}, //libnickel 4.20.14622 * _ZN17SelectionMenuView11addMenuItemEP12MenuTextItem
@@ -411,7 +428,27 @@ extern "C" __attribute__((visibility("default"))) void _nm_menu_hook2(MainNavVie
             return;
         }
 
-        NickelTouchMenu_NickelTouchMenu(menu, nullptr, 3);
+        // NickelMenu+Librito: make the from-scratch main-menu popover's pointer
+        // decoration and position configurable. Defaults preserve stock behaviour
+        // (decoration 3 = no caret, zero offset), so this is a no-op unless set.
+        // `decoration` is the DecorationPosition enum Nickel draws its native
+        // popover caret with; offset_x/_y nudge the popup so the caret lands on
+        // the tab button and add a screen-edge margin.
+        const char *nm_deco_s  = nm_global_config_experimental("menu_main_15505_decoration");
+        const char *nm_offx_s  = nm_global_config_experimental("menu_main_15505_offset_x");
+        const char *nm_offy_s  = nm_global_config_experimental("menu_main_15505_offset_y");
+        const char *nm_caret_s = nm_global_config_experimental("menu_main_15505_caret");
+        int  nm_deco  = nm_deco_s ? (int) strtol(nm_deco_s, nullptr, 10) : 3;
+        int  nm_offx  = nm_offx_s ? (int) strtol(nm_offx_s, nullptr, 10) : 0;
+        int  nm_offy  = nm_offy_s ? (int) strtol(nm_offy_s, nullptr, 10) : 0;
+        bool nm_caret = nm_caret_s && nm_caret_s[0] == '1';
+
+        // The caret (drawDecoration) hard-requires a parent widget: its first
+        // check is `if (!d->parent) return`, and it maps the caret anchor point
+        // via parent->mapFromGlobal(). Parent to the top-level window (global ≈
+        // window coords). Without the caret, keep the stock nullptr parent.
+        QWidget *nm_parent = nm_caret ? btn->window() : nullptr;
+        NickelTouchMenu_NickelTouchMenu(menu, nm_parent, nm_deco);
 
         for (size_t i = 0; i < items_n; i++) {
             nm_menu_item_t *it = items[i];
@@ -471,8 +508,40 @@ extern "C" __attribute__((visibility("default"))) void _nm_menu_hook2(MainNavVie
 
         QWidget::connect(menu, &QMenu::aboutToHide, menu, &QWidget::deleteLater);
 
+        // NickelMenu+Librito: enable the native popover caret when requested.
+        // paintEvent only calls drawDecoration if showDecoration(true) was set,
+        // and drawDecoration aims the caret at setTargetRect()'s centre — so both
+        // are required. setDecorationPosition picks the edge (0..4; 5 = none).
+        NM_LOG("librito caret: nm_caret=%d deco=%d haveShowDeco=%d haveSetTgt=%d haveSetPos=%d",
+            (int) nm_caret, nm_deco,
+            NickelTouchMenu_showDecoration != nullptr,
+            NickelTouchMenu_setTargetRect != nullptr,
+            NickelTouchMenu_setDecorationPosition != nullptr);
+        if (nm_caret && NickelTouchMenu_showDecoration && NickelTouchMenu_setTargetRect) {
+            NickelTouchMenu_showDecoration(menu, true);
+            if (NickelTouchMenu_setDecorationPosition)
+                NickelTouchMenu_setDecorationPosition(menu, nm_deco);
+            QRect nm_tgt(btn->mapToGlobal(QPoint(0, 0)), btn->size());
+            NickelTouchMenu_setTargetRect(menu, nm_tgt);
+            // The caret aims at this global point (stored at +0x4c; drawDecoration
+            // maps it into parent coords and adds half the target rect's width
+            // itself), so pass the target's top-left, NOT its centre. caret_dx/_dy
+            // allow config-only nudging of the anchor.
+            if (NickelTouchMenu_setDecorationPositionOffset) {
+                const char *nm_cdx_s = nm_global_config_experimental("menu_main_15505_caret_dx");
+                const char *nm_cdy_s = nm_global_config_experimental("menu_main_15505_caret_dy");
+                int nm_cdx = nm_cdx_s ? (int) strtol(nm_cdx_s, nullptr, 10) : 0;
+                int nm_cdy = nm_cdy_s ? (int) strtol(nm_cdy_s, nullptr, 10) : 0;
+                QPoint nm_anchor = nm_tgt.topLeft() + QPoint(nm_cdx, nm_cdy);
+                NickelTouchMenu_setDecorationPositionOffset(menu, nm_anchor);
+                NM_LOG("librito caret: anchor=(%d,%d)", nm_anchor.x(), nm_anchor.y());
+            }
+            NM_LOG("librito caret: ENABLED deco=%d parent=%p target=(%d,%d %dx%d)",
+                nm_deco, (void*) nm_parent, nm_tgt.x(), nm_tgt.y(), nm_tgt.width(), nm_tgt.height());
+        }
+
         menu->ensurePolished();
-        menu->popup(btn->mapToGlobal(btn->geometry().topRight() - QPoint(0, menu->sizeHint().height())));
+        menu->popup(btn->mapToGlobal(btn->geometry().topRight() - QPoint(0, menu->sizeHint().height()) + QPoint(nm_offx, nm_offy)));
     });
 
     bl->addWidget(btn, 1);


### PR DESCRIPTION

<img width="2200" height="1300" alt="PR upstream NickelMenu" src="https://github.com/user-attachments/assets/784a1ada-19e2-45bc-afaf-df679a78d00e" />

## Summary

On firmware 4.23.15505+, where the original main menu was removed, NickelMenu builds its menu from scratch as a bare `NickelTouchMenu`. Stock Nickel popovers (e.g. the brightness and battery popovers) draw a pointer caret aimed at their anchor, sit inset from the screen edge, and use full-width dividers — the from-scratch menu has none of that. This adds a handful of **opt-in** `experimental:` options to bring it closer to the native look.

Everything here defaults to the current behaviour, so an unset config renders exactly as before (the left screenshot above is this branch with no options set).

## Options added

All under the existing `menu_main_15505_*` experimental namespace:

| Option                  | Effect                                                             |
| ----------------------- | ------------------------------------------------------------------ |
| `caret`                 | draw the native popover caret, aimed at the NickelMenu tab         |
| `decoration`            | caret edge (`0` top, `3` bottom; `1`/`2` the side edges, `5` none) |
| `caret_dx` / `caret_dy` | nudge the caret anchor                                             |
| `offset_x` / `offset_y` | nudge the popup position (e.g. a screen-edge margin)               |
| `width`                 | fixed popover width (default auto-size)                            |
| `flush_separators`      | full-width dividers via Nickel's own separator                     |
| `separator_inset`       | inset for the above, to line up with the painted border            |
| `italic`                | `0` renders item labels upright                                    |

## Notes on the implementation

A few things were needed beyond what the existing code does, in case they're useful context for review:

- The caret only paints if the menu has a parent (`drawDecoration` returns early
  otherwise), `showDecoration(true)` is set (gated in `paintEvent`), and a target
  rect is given — so the menu is now parented to the tab button's window when the
  caret is requested.
- `offset_x/_y` are applied with `move()` _after_ `popup()`, because `popup()`'s
  screen-fit clamping otherwise swallows them.
- `flush_separators` adds a `LightMenuSeparator` and widens it after layout,
  since the menu insets every action.
- `italic 0` calls `MenuTextItem::setTextItalics(false)` after `setText()`
  (the constructor flag alone doesn't stick, as `setText` re-applies italics).

The four new `NickelTouchMenu`/`MenuTextItem` symbols are resolved optionally, so
firmware without them just falls back to the current appearance.

## Testing

Built with `nickeltc:1.0` and verified on a Kobo Libra Colour, FW 4.45.23697.
Symbol tags follow the existing entries (`4.23.15505 *`); CI will confirm across
versions.

## A question on defaults

I've kept everything opt-in here to stay conservative — but I wanted to raise one idea:

The pointer/caret and full-width dividers are arguably less "a styling option" and more "the native Kobo look this menu is currently missing".

NickelMenu's menus look native because they _are_ native widgets, and the 15505+ popover is the one element that doesn't (flat box, inset dividers, no caret/pointer) only because it's built from scratch rather than reused.

So — would you want the **caret, full-width dividers, and a small edge margin on by default** for the 15505+ menu, with width / italic staying opt-in? The caret anchor is derived from the tab button's own geometry, so it's device-independent, and the margin is just a small fixed inset; width and italic are the user-taste parts, which I'd suggest stay opt-in regardless.

No presumption either way — happy to leave it fully opt-in as in this PR, flip those to default, or whatever fits your appetite for a behaviour change. The "match native" angle just felt worth raising.

Thanks for your work on NickelMenu so far :)

> Disclosure: I developed this with Claude Code (also noted in the commit
> trailers). The reverse-engineering, build, and on-device testing were all
> verified on hardware, and I'm happy to walk through any of it in review.
